### PR TITLE
Retrieve Azure computer names from Node label if available

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -665,11 +665,16 @@ func (ss *scaleSet) getNodeIdentityByNodeName(nodeName string, crt azcache.Azure
 		return node, nil
 	}
 
-	if _, err := getScaleSetVMInstanceID(nodeName); err != nil {
+	computerName, ok := ss.Cloud.nodeComputerNames[nodeName]
+	if !ok {
+		computerName = nodeName
+	}
+
+	if _, err := getScaleSetVMInstanceID(computerName); err != nil {
 		return nil, err
 	}
 
-	node, err := getter(nodeName, crt)
+	node, err := getter(computerName, crt)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +683,7 @@ func (ss *scaleSet) getNodeIdentityByNodeName(nodeName string, crt azcache.Azure
 	}
 
 	klog.V(2).Infof("Couldn't find VMSS for node %s, refreshing the cache", nodeName)
-	node, err = getter(nodeName, azcache.CacheReadTypeForceRefresh)
+	node, err = getter(computerName, azcache.CacheReadTypeForceRefresh)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We'd like to set node names within Kubernetes that are disjoint from the `.compute.osProfile.computerName` relied on by Azure VMSSs in identifying VMs, however, doing this currently makes it impossible to attach disks to renamed nodes. This is a simple change which extracts Azure's `computerName` from the node label `kubernetes.azure.com/computer-name` if it exists on a node.