### PR TITLE
Allow configuring DaemonSet controller burst replicas

### DIFF
--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -54,6 +54,7 @@ func newDaemonSetController(ctx context.Context, controllerContext ControllerCon
 		controllerContext.InformerFactory.Core().V1().Nodes(),
 		client,
 		flowcontrol.NewBackOff(1*time.Second, 15*time.Minute),
+		int(controllerContext.ComponentConfig.DaemonSetController.BurstReplicas),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DaemonSets controller: %w", err)

--- a/cmd/kube-controller-manager/app/options/daemonsetcontroller.go
+++ b/cmd/kube-controller-manager/app/options/daemonsetcontroller.go
@@ -36,6 +36,7 @@ func (o *DaemonSetControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.Int32Var(&o.ConcurrentDaemonSetSyncs, "concurrent-daemonset-syncs", o.ConcurrentDaemonSetSyncs, "The number of daemonset objects that are allowed to sync concurrently. Larger number = more responsive daemonsets, but more CPU (and network) load")
+	fs.Int32Var(&o.BurstReplicas, "daemonset-burst-replicas", o.BurstReplicas, "The maximum number of pods the daemonset controller will create/delete in a single sync. Larger number = faster rollouts, but risks registry/API DoS")
 }
 
 // ApplyTo fills up DaemonSetController config with options.
@@ -45,6 +46,7 @@ func (o *DaemonSetControllerOptions) ApplyTo(cfg *daemonconfig.DaemonSetControll
 	}
 
 	cfg.ConcurrentDaemonSetSyncs = o.ConcurrentDaemonSetSyncs
+	cfg.BurstReplicas = o.BurstReplicas
 
 	return nil
 }
@@ -58,6 +60,9 @@ func (o *DaemonSetControllerOptions) Validate() []error {
 	errs := []error{}
 	if o.ConcurrentDaemonSetSyncs < 1 {
 		errs = append(errs, fmt.Errorf("concurrent-daemonset-syncs must be greater than 0, but got %d", o.ConcurrentDaemonSetSyncs))
+	}
+	if o.BurstReplicas < 1 {
+		errs = append(errs, fmt.Errorf("daemonset-burst-replicas must be greater than 0, but got %d", o.BurstReplicas))
 	}
 	return errs
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -270,6 +270,7 @@ func TestAddFlags(t *testing.T) {
 		DaemonSetController: &DaemonSetControllerOptions{
 			&daemonconfig.DaemonSetControllerConfiguration{
 				ConcurrentDaemonSetSyncs: 10,
+				BurstReplicas:            250,
 			},
 		},
 		DeploymentController: &DeploymentControllerOptions{

--- a/pkg/controller/daemon/config/types.go
+++ b/pkg/controller/daemon/config/types.go
@@ -22,4 +22,8 @@ type DaemonSetControllerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive daemonset,
 	// but more CPU (and network) load.
 	ConcurrentDaemonSetSyncs int32
+
+	// burstReplicas is the maximum number of pods the controller will create/delete
+	// in a single sync. Larger number = faster rollouts but risks registry/API DoS.
+	BurstReplicas int32
 }

--- a/pkg/controller/daemon/config/v1alpha1/defaults.go
+++ b/pkg/controller/daemon/config/v1alpha1/defaults.go
@@ -33,4 +33,7 @@ func RecommendedDefaultDaemonSetControllerConfiguration(obj *kubectrlmgrconfigv1
 	if obj.ConcurrentDaemonSetSyncs == 0 {
 		obj.ConcurrentDaemonSetSyncs = 2
 	}
+	if obj.BurstReplicas == 0 {
+		obj.BurstReplicas = daemon.DefaultBurstReplicas
+	}
 }

--- a/pkg/controller/daemon/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/daemon/config/v1alpha1/zz_generated.conversion.go
@@ -61,11 +61,13 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_DaemonSetControllerConfiguration_To_config_DaemonSetControllerConfiguration(in *configv1alpha1.DaemonSetControllerConfiguration, out *config.DaemonSetControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentDaemonSetSyncs = in.ConcurrentDaemonSetSyncs
+	out.BurstReplicas = in.BurstReplicas
 	return nil
 }
 
 func autoConvert_config_DaemonSetControllerConfiguration_To_v1alpha1_DaemonSetControllerConfiguration(in *config.DaemonSetControllerConfiguration, out *configv1alpha1.DaemonSetControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentDaemonSetSyncs = in.ConcurrentDaemonSetSyncs
+	out.BurstReplicas = in.BurstReplicas
 	return nil
 }
 

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -56,9 +56,9 @@ import (
 )
 
 const (
-	// BurstReplicas is a rate limiter for booting pods on a lot of pods.
+	// DefaultBurstReplicas is the default rate limit for creating/deleting pods per sync.
 	// The value of 250 is chosen b/c values that are too high can cause registry DoS issues.
-	BurstReplicas = 250
+	DefaultBurstReplicas = 250
 
 	// StatusUpdateRetries limits the number of retries if sending a status update to API server fails.
 	StatusUpdateRetries = 1
@@ -145,6 +145,7 @@ func NewDaemonSetsController(
 	nodeInformer coreinformers.NodeInformer,
 	kubeClient clientset.Interface,
 	failedPodsBackoff *flowcontrol.Backoff,
+	burstReplicas int,
 ) (*DaemonSetsController, error) {
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	logger := klog.FromContext(ctx)
@@ -159,7 +160,7 @@ func NewDaemonSetsController(
 		crControl: controller.RealControllerRevisionControl{
 			KubeClient: kubeClient,
 		},
-		burstReplicas: BurstReplicas,
+		burstReplicas: burstReplicas,
 		expectations:  controller.NewControllerExpectations(),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -323,6 +323,7 @@ func newTestController(ctx context.Context, initialObjects ...runtime.Object) (*
 		informerFactory.Core().V1().Nodes(),
 		clientset,
 		flowcontrol.NewFakeBackOff(50*time.Millisecond, 500*time.Millisecond, testingclock.NewFakeClock(time.Now())),
+		DefaultBurstReplicas,
 	)
 	if err != nil {
 		return nil, nil, nil, err
@@ -496,6 +497,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		f.Core().V1().Nodes(),
 		client,
 		flowcontrol.NewFakeBackOff(50*time.Millisecond, 500*time.Millisecond, testingclock.NewFakeClock(time.Now())),
+		DefaultBurstReplicas,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -65469,8 +65469,16 @@ func schema_k8sio_kube_controller_manager_config_v1alpha1_DaemonSetControllerCon
 							Format:      "int32",
 						},
 					},
+					"BurstReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "burstReplicas is the maximum number of pods the daemonset controller will create/delete in a single sync. Larger number = faster rollouts but risks registry/API DoS.",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
-				Required: []string{"ConcurrentDaemonSetSyncs"},
+				Required: []string{"ConcurrentDaemonSetSyncs", "BurstReplicas"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -228,6 +228,10 @@ type DaemonSetControllerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive daemonset,
 	// but more CPU (and network) load.
 	ConcurrentDaemonSetSyncs int32
+	// burstReplicas is the maximum number of pods the daemonset controller will
+	// create/delete in a single sync. Larger number = faster rollouts but risks
+	// registry/API DoS.
+	BurstReplicas int32
 }
 
 // DeploymentControllerConfiguration contains elements describing DeploymentController.

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -89,6 +89,7 @@ func setupWithServerSetup(t *testing.T, serverSetup framework.TestServerSetup) (
 		informers.Core().V1().Nodes(),
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "daemonset-controller")),
 		flowcontrol.NewBackOff(5*time.Second, 15*time.Minute),
+		daemon.DefaultBurstReplicas,
 	)
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)


### PR DESCRIPTION
## Summary
- add a  field to DaemonSet controller config with default 250
- expose  flag and plumb the value into the controller
- update API conversions/openapi and tests to honor the configurable limit

## Testing
- go test ./pkg/controller/daemon -run TestExpectationsOnRecreate -count=1
